### PR TITLE
Return detailed erorrs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-registry-serdes",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/schema-errors.js
+++ b/src/lib/schema-errors.js
@@ -1,0 +1,27 @@
+/** @typedef { import('../types').EncodingValidationError } EncodingValidationError */
+
+class ValidationError extends TypeError {
+    /**
+     * @param {Array<EncodingValidationError>} validationErrors 
+     */
+    constructor(validationErrors) {
+        super('Failed to encode message with given schema')
+        this.name = 'AvroSchemaValidationError'
+        this.validationErrors = validationErrors
+    }
+
+    toJSON() {
+        return {
+          error: {
+            name: this.name,
+            message: this.message,
+            stacktrace: this.stack,
+            errors: this.validationErrors
+          }
+        }
+    }
+}
+
+module.exports = {
+    ValidationError
+}

--- a/src/schema-registry.js
+++ b/src/schema-registry.js
@@ -23,7 +23,7 @@ const validateEncodedMessage = (message, schema) => {
     schema.isValid(message, {
         errorHook: (path, value, type) => {
             errors.push({
-                path,
+                path: path.join('.'),
                 value,
                 expectedType: type.toString()
             })

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,22 @@
+export interface EncodingValidationError {
+    /**
+     * Path of the field that failed validation
+    */
+    path: string
+    /**
+     * Value of the field that failed to be decoded
+    */
+    value: any
+    /**
+     * Type that the schema expects the value to be.
+    */
+    expectedType: string
+}
+
+export interface SchemaRegistryOptions {
+    /**
+     * Set to true get better error messages when the message being sent doesn't match.
+     * **Note that this has significant impact on performance and should only be enabled for development.**
+     */
+    validateEncodedMessages: boolean
+}


### PR DESCRIPTION
Adds the option to validate messages against the schema before sending the messages. This is very helpful for development.

Note that, as mentioned in the code documentation, this should only be enabled in development due to its [impact on performance](https://github.com/mtth/avsc/issues/190#issuecomment-401507243).

## Usage ##
```js
const registry = new SchemaRegistry(config.schemaRegistryUrl, {
			validateEncodedMessages: true,
		});
```

## Example error output ###

### With validation enabled ###
```
{ AvroSchemaValidationError: Failed to encode message with given schema
    at SchemaRegistry._getMessageEncoded (/Users/henry/projects/opensource/schema-registry-serdes/src/schema-registry.js:68:23)
    at SchemaRegistry._encodeBySchema (/Users/henry/projects/opensource/schema-registry-serdes/src/schema-registry.js:116:35)
    at SchemaRegistry.encodeMessage (/Users/henry/projects/opensource/schema-registry-serdes/src/schema-registry.js:147:34)
    at Producer.sendEncodedMessage (/Users/henry/projects/kafka-client/src/Producer.js:88:46)
    at /Users/henry/projects/libraries/kafka-client/examples/send-encoded-message.js:17:33
    at process._tickCallback (internal/process/next_tick.js:68:7)
  name: 'AvroSchemaValidationError',
  validationErrors:
   [ { path: 'tenantId', value: undefined, expectedType: '"string"' },
     { path: 'domain', value: undefined, expectedType: '"string"' },
     { path: 'subDomain', value: undefined, expectedType: '"string"' },
     { path: 'context', value: undefined, expectedType: '"string"' },
     { path: 'error.code', value: false, expectedType: '"string"' },
     { path: 'error.message',
       value: undefined,
       expectedType: '"string"' },
     { path: 'error.details',
       value: undefined,
       expectedType: '"string"' } ] }
```

### Without validation enabled ###
```
Error: invalid "string": undefined
    at throwInvalidError (/Users/henry/projects/opensource/schema-registry-serdes/node_modules/avsc/lib/types.js:3023:9)
    at StringType._write (/Users/henry/projects/opensource/schema-registry-serdes/node_modules/avsc/lib/types.js:1077:5)
    at RecordType.writeAxios [as _write] (eval at RecordType._createWriter (/Users/henry/projects/opensource/schema-registry-serdes/node_modules/avsc/lib/types.js:2318:10), <anonymous>:5:6)
    at RecordType.Type.toBuffer (/Users/henry/projects/opensource/schema-registry-serdes/node_modules/avsc/lib/types.js:652:8)
    at SchemaRegistry._getMessageEncoded (/Users/henry/projects/opensource/schema-registry-serdes/src/schema-registry.js:72:41)
    at SchemaRegistry._encodeBySchema (/Users/henry/projects/opensource/schema-registry-serdes/src/schema-registry.js:116:35)
    at SchemaRegistry.encodeMessage (/Users/henry/projects/opensource/schema-registry-serdes/src/schema-registry.js:147:34)
    at Producer.sendEncodedMessage (/Users/henry/projects/libraries/kafka-client/src/Producer.js:88:46)
    at /Users/henry/projects/libraries/kafka-client/examples/send-encoded-message.js:17:33
    at process._tickCallback (internal/process/next_tick.js:68:7)
```